### PR TITLE
Support for more models

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
+DATABASE_URL=postgres://postgres:postgres@db:5432/promptspot_development
 OPENAI_API_SECRET=sk-1234567890abcdef1234567890abcdef12345678
-DATABASE_URL=DATABASE_URL=postgres://postgres:postgres@db:5432/postgres
+

--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -10,13 +10,13 @@
       <jdbc-url>jdbc:postgresql://127.0.0.1:5432/hotelbot_rails_test</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
-    <data-source source="LOCAL" name="hotelbot-rails: development" uuid="afb3f0cf-c7ef-45e3-ad51-a3ff314ab5f0">
+    <data-source source="LOCAL" name="promptspot_development" uuid="afb3f0cf-c7ef-45e3-ad51-a3ff314ab5f0">
       <driver-ref>postgresql</driver-ref>
       <synchronize>true</synchronize>
       <imported>true</imported>
       <remarks>$PROJECT_DIR$/config/database.yml</remarks>
       <jdbc-driver>org.postgresql.Driver</jdbc-driver>
-      <jdbc-url>jdbc:postgresql://127.0.0.1:5432/hotelbot_rails_development</jdbc-url>
+      <jdbc-url>jdbc:postgresql://localhost:5432/promptspot_development</jdbc-url>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
     <data-source source="LOCAL" name="hotelbot-rails: production" uuid="ec4d9d76-f036-4f57-844a-215f5023e190">

--- a/app/controllers/inputs_controller.rb
+++ b/app/controllers/inputs_controller.rb
@@ -66,6 +66,6 @@ class InputsController < ApplicationController
   end
 
   def input_params
-    params.require(:input).permit(:text)
+    params.require(:input).permit(:text, :title)
   end
 end

--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -33,6 +33,10 @@ class PromptsController < ApplicationController
   end
 
   def create
+    if @current_organization.openai_api_key.blank? && @prompt.title.nil?
+      flash[:error] = "Please set your OpenAI API key first."
+      redirect_to edit_user_registration_url_ and return
+    end
     @prompt = Prompt.new(prompt_params)
     @prompt.account_id = current_user.account.id
     @prompt.prompt_versions.build if @prompt.prompt_versions.empty?
@@ -40,6 +44,7 @@ class PromptsController < ApplicationController
     draft_id = params[:prompt_draft_id]
 
     respond_to do |format|
+
       if @prompt.save
         if draft_id.present?
           PromptDraft.find(draft_id).destroy

--- a/app/controllers/prompts_controller.rb
+++ b/app/controllers/prompts_controller.rb
@@ -33,11 +33,11 @@ class PromptsController < ApplicationController
   end
 
   def create
-    if @current_organization.openai_api_key.blank? && @prompt.title.nil?
-      flash[:error] = "Please set your OpenAI API key first."
-      redirect_to edit_user_registration_url_ and return
-    end
     @prompt = Prompt.new(prompt_params)
+    if @current_organization.openai_api_key.blank? && @prompt.title.blank?
+      flash[:error] = "Please set your OpenAI API key first."
+      redirect_to edit_user_registration_url and return
+    end
     @prompt.account_id = current_user.account.id
     @prompt.prompt_versions.build if @prompt.prompt_versions.empty?
     @prompt.prompt_versions.last.user = current_user

--- a/app/models/input.rb
+++ b/app/models/input.rb
@@ -4,7 +4,7 @@ class Input < ApplicationRecord
   has_many :inputs
   has_many :test_suites, through: :test_suite_inputs
   validates :text, presence: true
-  before_create :generate_prompt_summary
+  before_validation :generate_input_title, on: :create
 
   def tests
     TestSuite.joins(test_suite_inputs: :input)
@@ -14,7 +14,8 @@ class Input < ApplicationRecord
 
   private
 
-  def generate_prompt_summary
+  def generate_input_title
+    return if title.present? # Don't autogenerate a title if the user has already set one
     summary = Rails.application.config.title_system_prompt + '"""' + text + '"""'
     # Use the organization's OpenAI API key if it exists, otherwise use the environment variable
     client = OpenAI::Client.new(access_token: account.organization&.openai_api_key.presence || ENV["OPENAI_API_SECRET"])
@@ -25,7 +26,7 @@ class Input < ApplicationRecord
         max_tokens: 15
       }
     )
-    self.title = response["choices"][0]["text"]
+    self.title = response["choices"][0]["text"] if title.blank?
   rescue StandardError => e
     puts "Error: #{e}"
   end

--- a/app/models/prompt_version.rb
+++ b/app/models/prompt_version.rb
@@ -39,6 +39,7 @@ class PromptVersion < ApplicationRecord
 
   def generate_prompt_title
     return unless version_number == 1 # Only autogenerate a title for the first version of the prompt
+    return if self.prompt.title.present? # Don't autogenerate a title if the user has already set one
     ActiveRecord::Base.transaction do
       summary = "#{Rails.application.config.title_system_prompt}\"\"\"#{text}\"\"\""
       # Use the organization's OpenAI API key if it exists, otherwise use the environment variable

--- a/app/models/test_run.rb
+++ b/app/models/test_run.rb
@@ -2,9 +2,12 @@ require 'csv'
 
 class TestRun < ApplicationRecord
   belongs_to :test_suite
+  has_many :test_run_models
+  has_many :models, through: :test_run_models
   has_many :test_run_details
   validates :archived, inclusion: { in: [true, false] }
   after_create :run
+  after_create :save_models
 
   def check_and_update_status
     if test_run_details.where(status: 'error').any?
@@ -59,6 +62,12 @@ class TestRun < ApplicationRecord
           )
         end
       end
+    end
+  end
+
+  def save_models
+    test_suite.models.each do |model|
+      TestRunModel.create(test_run_id: id, model_id: model.id)
     end
   end
 end

--- a/app/models/test_run_model.rb
+++ b/app/models/test_run_model.rb
@@ -1,0 +1,4 @@
+class TestRunModel < ApplicationRecord
+  belongs_to :test_run
+  belongs_to :model
+end

--- a/app/views/inputs/_form.html.erb
+++ b/app/views/inputs/_form.html.erb
@@ -13,7 +13,7 @@
   <% end %>
 
   <div class="field mb-6">
-    <%= form.text_field :title, class: "border border-gray-300 dark:border-slate-600 dark:bg-opacity-10 bg-white rounded-md text-2xl" %>
+    <%= form.text_field :title, placeholder: "Enter a title", class: "border border-gray-300 dark:border-slate-600 dark:bg-opacity-10 bg-white rounded-md text-2xl" %>
   </div>
   <div class="field flex flex-col">
     <%= form.text_area :text, id: :input_text, autofocus: true, class: "rounded-md border-gray-300 dark:border-slate-600 bg-white dark:bg-opacity-10 font-mono text-lg", rows: 20, placeholder: "Enter or paste your input text" %>

--- a/app/views/inputs/_form.html.erb
+++ b/app/views/inputs/_form.html.erb
@@ -12,11 +12,11 @@
     </div>
   <% end %>
 
-  <div class="field mb-6">
-    <%= form.text_field :title, placeholder: "Enter a title", class: "border border-gray-300 dark:border-slate-600 dark:bg-opacity-10 bg-white rounded-md text-2xl" %>
+  <div class="field mb-6 flex flex-col">
+    <%= form.text_field :title, placeholder: "Enter a title (optional)", class: "font-mono border border-gray-300 dark:border-slate-600 dark:bg-opacity-10 bg-white rounded-md text-lg" %>
   </div>
   <div class="field flex flex-col">
-    <%= form.text_area :text, id: :input_text, autofocus: true, class: "rounded-md border-gray-300 dark:border-slate-600 bg-white dark:bg-opacity-10 font-mono text-lg", rows: 20, placeholder: "Enter or paste your input text" %>
+    <%= form.text_area :text, id: :input_text, class: "rounded-md border-gray-300 dark:border-slate-600 bg-white dark:bg-opacity-10 font-mono text-lg", rows: 20, placeholder: "Enter or paste your input text" %>
   </div>
 
   <div class="actions mt-4 flex flex-row">

--- a/app/views/inputs/edit.html.erb
+++ b/app/views/inputs/edit.html.erb
@@ -16,6 +16,7 @@
         <% end %>
       <% end %>
     <% end %>
+    <%= button_to 'Delete input', input_url(@input), method: :delete, class: "flex items-center justify-center rounded-md py-2 px-3 bg-white dark:bg-opacity-10 dark:border-slate-500 border border-red-200 dark:text-red-300 text-red-600 dark:hover:bg-slate-600 hover:bg-white font-medium cursor-pointer mt-5" %>
   </div>
 </div>
 

--- a/app/views/inputs/index.html.erb
+++ b/app/views/inputs/index.html.erb
@@ -18,7 +18,7 @@
   </div>
 <% else %>
   <div class="text-center mt-24">
-    <p class="text-gray-500">No inputs
-      yet. <%= link_to 'Create an input', new_input_path, class: 'text-black hover:underline' %></p>
+    <p class="text-gray-400 text-2xl">No inputs yet.
+      <%= link_to 'Create an input', new_input_path, class: 'text-blue-500 hover:underline' %></p>
   </div>
 <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,12 +12,7 @@
 </head>
 
 <body class="flex min-h-screen bg-gray-900 dark:bg-gray-900 dark:text-white">
-<nav class="w-48 p-8 bg-white dark:bg-slate-700 border-r dark:border-slate-700 border-gray-200 flex flex-col min-h-screen overflow-y-auto scrollbar-hide">
-  <!--  <div class="mb-4 font-bold text-2xl text-blue-600 tracking-tight">-->
-  <%#= link_to root_path do %>
-  <%#= image_tag("promptspot-logo.svg", class: "h-6") %>
-  <%# end %>
-  <!--  </div>-->
+<nav class="w-48 flex-shrink-0 p-8 bg-white dark:bg-slate-700 border-r dark:border-slate-700 border-gray-200 flex flex-col min-h-screen overflow-y-auto scrollbar-hide">
   <div class="flex-grow">
     <ul class="flex flex-col font-mono font-medium text-gray-700 tracking-wider">
       <% if current_user %>

--- a/app/views/prompts/_form.html.erb
+++ b/app/views/prompts/_form.html.erb
@@ -11,7 +11,7 @@
     </div>
   <% end %>
   <div class="field mb-6">
-    <%= form.text_field :title, class: "text-2xl dark:bg-opacity-10 bg-white rounded-md border dark:border-slate-600 border-gray-300 w-full" %>
+    <%= form.text_field :title, placeholder: "Enter a title", class: "text-2xl dark:bg-opacity-10 bg-white rounded-md border dark:border-slate-600 border-gray-300 w-full" %>
   </div>
 
   <%= form.fields_for :prompt_versions, @new_prompt_version do |prompt_version_form| %>

--- a/app/views/prompts/_form.html.erb
+++ b/app/views/prompts/_form.html.erb
@@ -10,8 +10,8 @@
       </ul>
     </div>
   <% end %>
-  <div class="field mb-6">
-    <%= form.text_field :title, placeholder: "Enter a title", class: "text-2xl dark:bg-opacity-10 bg-white rounded-md border dark:border-slate-600 border-gray-300 w-full" %>
+  <div class="field mb-6 flex flex-col">
+    <%= form.text_field :title, placeholder: "Enter a title (optional)", class: "font-mono text-lg dark:bg-opacity-10 bg-white rounded-md border dark:border-slate-600 border-gray-300 w-full" %>
   </div>
 
   <%= form.fields_for :prompt_versions, @new_prompt_version do |prompt_version_form| %>

--- a/app/views/prompts/index.html.erb
+++ b/app/views/prompts/index.html.erb
@@ -17,7 +17,7 @@
   </div>
 <% else %>
   <div class="text-center mt-24">
-    <p class="text-gray-500">No prompts
-      yet. <%= link_to 'Create a prompt', new_prompt_path, class: 'text-black hover:underline' %></p>
+    <p class="text-gray-400 text-2xl">No prompts yet.
+      <%= link_to 'Create a prompt', new_prompt_path, class: 'text-blue-500 hover:underline' %></p>
   </div>
 <% end %>

--- a/app/views/test_runs/_row.html.erb
+++ b/app/views/test_runs/_row.html.erb
@@ -5,6 +5,11 @@
     <!--    Do not use @current_organization here because this row gets turbo-streamed from the model-->
     <%= test_run.run_time&.in_time_zone(test_run.test_suite.account.organization.timezone)&.strftime('%B %e, %l:%M %p') %>
   </td>
+  <td>
+    <% test_run.models.each do |model| %>
+      <p class="font-mono font-medium text-gray-600 text-xs rounded-full bg-gray-200 px-2 py-1 mr-2 flex inline-flex items-center justify-center"><%= model.name %>
+    <% end %>
+  </td>
   <td class="px-4 py-2 flex items-center justify-end flex-row">
     <% if test_run.status != "running" %>
       <%= button_to 'Archive', archive_test_suite_test_run_path(test_suite, test_run), class: 'flex inline-flex rounded items-center justify-center font-medium px-2 py-1 border border bg-blue-50 dark:bg-slate-700 dark:border-slate-500 dark:text-white border border-blue-200 text-blue-600 dark:hover:bg-slate-600 hover:bg-white font-medium mx-2' %>

--- a/app/views/test_suites/_form.html.erb
+++ b/app/views/test_suites/_form.html.erb
@@ -98,14 +98,11 @@
           >
             <p class="font-mono text-lg"><%= m.name %></p>
             <p class="text-sm text-gray-500 mt-2"><%= m.model_provider.name %></p>
-            <p class="mt-2 text-gray-500"><%= m.description %></p>
+            <p class="mt-2 text-gray-500 text-sm"><%= m.description %></p>
           </div>
         <% end %>
       </div>
     </div>
-    <p class="ml-12 text-gray-400 text-sm text-right w-72 flex-shrink-0">
-      Currently built for completion tasks. More models coming soon, including chat-based models.
-    </p>
   </div>
 
   <%= form.hidden_field :mode, value: 'completion' %>

--- a/app/views/test_suites/_test_suite.html.erb
+++ b/app/views/test_suites/_test_suite.html.erb
@@ -16,12 +16,7 @@
         </span>
         <% end %>
       </div>
-      <div class="flex flex-wrap items-center mt-2">
-        <% test_suite.models.each do |m| %>
-          <p class="font-mono font-medium text-gray-600 text-xs rounded-full bg-gray-200 px-2 py-1 mr-2 flex items-center justify-center"><%= m.name %>
-          </p>
-        <% end %>
-      </div>
+
     </div>
     <div class="flex items-center">
       <% if test_suite.test_runs.length > 0 %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -1,87 +1,18 @@
-# PostgreSQL. Versions 9.3 and up are supported.
-#
-# Install the pg driver:
-#   gem install pg
-# On macOS with Homebrew:
-#   gem install pg -- --with-pg-config=/usr/local/bin/pg_config
-# On macOS with MacPorts:
-#   gem install pg -- --with-pg-config=/opt/local/lib/postgresql84/bin/pg_config
-# On Windows:
-#   gem install pg
-#       Choose the win32 build.
-#       Install PostgreSQL and put its /bin directory on your path.
-#
-# Configure Using Gemfile
-# gem "pg"
-#
 default: &default
   adapter: postgresql
   encoding: unicode
-  # For details on connection pooling, see Rails configuration guide
-  # https://guides.rubyonrails.org/configuring.html#database-pooling
+  host: db
+  port: 5432
   pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
-  url: <%= ENV['DATABASE_URL'] %>
-
 
 development:
   <<: *default
+  database: promptspot_development
+  username: postgres
+  password: postgres
 
-  # The specified database role being used to connect to postgres.
-  # To create additional roles in postgres see `$ createuser --help`.
-  # When left blank, postgres will use the default role. This is
-  # the same name as the operating system user running Rails.
-  #username: promptspot
-
-  # The password associated with the postgres role (username).
-  #password:
-
-  # Connect on a TCP socket. Omitted by default since the client uses a
-  # domain socket that doesn't need configuration. Windows does not have
-  # domain sockets, so uncomment these lines.
-  #host: localhost
-
-  # The TCP port the server listens on. Defaults to 5432.
-  # If your server runs on a different port number, change accordingly.
-  #port: 5432
-
-  # Schema search path. The server defaults to $user,public
-  #schema_search_path: myapp,sharedapp,public
-
-  # Minimum log levels, in increasing order:
-  #   debug5, debug4, debug3, debug2, debug1,
-  #   log, notice, warning, error, fatal, and panic
-  # Defaults to warning.
-  #min_messages: notice
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
 test:
   <<: *default
   database: promptspot_test
-
-# As with config/credentials.yml, you never want to store sensitive information,
-# like your database password, in your source code. If your source code is
-# ever seen by anyone, they now have access to your database.
-#
-# Instead, provide the password or a full connection URL as an environment
-# variable when you boot the app. For example:
-#
-#   DATABASE_URL="postgres://myuser:mypass@localhost/somedatabase"
-#
-# If the connection URL is provided in the special DATABASE_URL environment
-# variable, Rails will automatically merge its configuration values on top of
-# the values provided in this file. Alternatively, you can specify a connection
-# URL environment variable explicitly:
-#
-#   production:
-#     url: <%= ENV["DATABASE_URL"] %>
-#
-# Read https://guides.rubyonrails.org/configuring.html#configuring-a-database
-# for a full overview on how database connection configuration can be specified.
-#
-production:
-  <<: *default
-  database: promptspot_production
-  username: promptspot
-  password: <%= ENV["PROMPTSPOT_DATABASE_PASSWORD"] %>
+  username: postgres
+  password: postgres

--- a/db/migrate/20230707131601_add_test_run_models_table.rb
+++ b/db/migrate/20230707131601_add_test_run_models_table.rb
@@ -1,0 +1,9 @@
+class AddTestRunModelsTable < ActiveRecord::Migration[7.0]
+  def change
+    create_table :test_run_models do |t|
+      t.references :test_run, null: false, foreign_key: true, type: :uuid
+      t.references :model, null: false, foreign_key: true, type: :uuid
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_06_30_094519) do
+ActiveRecord::Schema[7.0].define(version: 2023_07_07_131601) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
@@ -178,6 +178,15 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_30_094519) do
     t.index ["prompt_version_id"], name: "index_test_run_details_on_prompt_version_id"
   end
 
+  create_table "test_run_models", force: :cascade do |t|
+    t.uuid "test_run_id", null: false
+    t.uuid "model_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["model_id"], name: "index_test_run_models_on_model_id"
+    t.index ["test_run_id"], name: "index_test_run_models_on_test_run_id"
+  end
+
   create_table "test_runs", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "test_suite_id"
     t.datetime "run_time"
@@ -238,5 +247,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_06_30_094519) do
   add_foreign_key "prompt_drafts", "prompts"
   add_foreign_key "prompt_drafts", "users"
   add_foreign_key "test_run_details", "prompt_versions"
+  add_foreign_key "test_run_models", "models"
+  add_foreign_key "test_run_models", "test_runs"
   add_foreign_key "test_suites", "accounts"
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,10 +4,10 @@
 model_provider = ModelProvider.find_or_create_by!(name: "OpenAI")
 
 models_data = [
-  { name: "gpt-3.5-turbo", description: "Most capable GPT-3.5 model. Optimized for chat.", enabled: false, model_type: "chat" },
+  { name: "gpt-3.5-turbo", description: "Most capable GPT-3.5 model. Optimized for chat.", enabled: true, model_type: "chat" },
   { name: "text-davinci-003", description: "Can do any language task, including prompt completion.", enabled: true, model_type: "completion" },
   { name: "code-davinci-002", description: "Optimized for code-completion tasks.", enabled: false, model_type: "code" },
-  { name: "gpt-4", description: "More capable than any GPT-3.5 model, able to do more complex tasks, and optimized for chat.", enabled: false, model_type: "chat" },
+  { name: "gpt-4", description: "More capable than any GPT-3.5 model, able to do more complex tasks, and optimized for chat.", enabled: true, model_type: "chat" },
   { name: "gpt-4-32k", description: "Same capabilities as the base gpt-4 model but with 4x the context length.", enabled: false, model_type: "chat" },
 ]
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -4,10 +4,10 @@
 model_provider = ModelProvider.find_or_create_by!(name: "OpenAI")
 
 models_data = [
-  { name: "gpt-3.5-turbo", description: "Most capable GPT-3.5 model. Optimized for chat.", enabled: true, model_type: "chat" },
-  { name: "text-davinci-003", description: "Can do any language task, including prompt completion.", enabled: true, model_type: "completion" },
+  { name: "gpt-3.5-turbo", description: "Most capable GPT-3.5 model.", enabled: true, model_type: "chat" },
+  { name: "text-davinci-003", description: "Can do any language task. Soon to be deprecated.", enabled: true, model_type: "completion" },
   { name: "code-davinci-002", description: "Optimized for code-completion tasks.", enabled: false, model_type: "code" },
-  { name: "gpt-4", description: "More capable than any GPT-3.5 model, able to do more complex tasks, and optimized for chat.", enabled: true, model_type: "chat" },
+  { name: "gpt-4", description: "More capable than any GPT-3.5 model, and able to do more complex tasks at a higher cost.", enabled: true, model_type: "chat" },
   { name: "gpt-4-32k", description: "Same capabilities as the base gpt-4 model but with 4x the context length.", enabled: false, model_type: "chat" },
 ]
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,10 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
       - POSTGRES_USER=postgres
-      - POSTGRES_DB=postgres
+      - POSTGRES_DB=promptspot_development
+    ports:
+      - "5432:5432"  # Expose PostgreSQL port to your local machine
+
   web:
     build: .
     command: bundle exec rails server -b '0.0.0.0'
@@ -19,9 +22,21 @@ services:
       - .env
     depends_on:
       - db
+
+  test:
+    build: .
+    command: bundle exec rails test
+    volumes:
+      - .:/promptspot
+    env_file:
+      - .env
+    depends_on:
+      - db
+
   redis:
     image: redis
     ports:
       - "6379:6379"
+
 volumes:
   postgres_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
     build: .
     command: bundle exec rails server -b '0.0.0.0'
     volumes:
-      - .:/app
+      - .:/promptspot
     ports:
       - "3000:3000"
     env_file:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,8 +4,9 @@ set -e
 # Wait for the DB to be ready
 dockerize -wait tcp://db:5432 -timeout 1m
 
-bin/rails db:seed
-bin/rails db:migrate
+# bin/rails db:seed
+# bin/rails db:migrate
+bin/rails db:setup
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile).
 exec "$@"


### PR DESCRIPTION
With the recent [announcement](https://openai.com/blog/gpt-4-api-general-availability) regarding chat vs completion models from OpenAI (tl;dr use chat, always, even for completions...), this change introduces support for chat-based models (i.e. `gpt-3.5-turbo` and `gpt-4`, now publicly available). Adding more models is as easy as adding them to the `seeds.rb` file, but they must be chat or completion type for now. 

<img width="760" alt="image" src="https://github.com/jordanful/Promptspot/assets/167483/8f191a91-f739-4db3-ad95-e1a5fffc4c9c">
